### PR TITLE
Fix doc patch

### DIFF
--- a/docs/index-md-replaces/env-vars-desired.md
+++ b/docs/index-md-replaces/env-vars-desired.md
@@ -2,6 +2,8 @@
   that are ignored by the provider when configuring the Nomad API client.
   Supported keys are: `NOMAD_NAMESPACE` and `NOMAD_REGION`.
 
+- `auth_jwt` - Authenticates to Nomad using a JWT authentication method.
+
 The `headers` nested type accepts the following arguments:
 * `name` - (Required) The name of the header.
 * `value` - (Required) The value of the header.

--- a/docs/index-md-replaces/env-vars-input.md
+++ b/docs/index-md-replaces/env-vars-input.md
@@ -10,6 +10,9 @@
     ```.
   Set these values to `false` if you need to load these environment variables.
 
+- `auth_jwt` `(block)` - Authenticates to Nomad using a JWT authentication method, described below.
+  This block can only be specified one time.
+
 The `headers` configuration block accepts the following arguments:
 * `name` - (Required) The name of the header.
 * `value` - (Required) The value of the header.


### PR DESCRIPTION
https://github.com/pulumi/pulumi-nomad/issues/640 is failing because the upstream docs are no longer matching.

I copied the current upstream docs verbatim into our expect inputs.